### PR TITLE
creating a venv to run dev tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,24 @@
 .PHONY: run bump-version lint fix-lint
 
+VENV_DIR:=.venv
+VENV_ACTIVATE:=source $(VENV_DIR)/bin/activate
+SOURCE_DIR:=src
+
+$(VENV_DIR):
+	python -m venv $@
+	$(VENV_ACTIVATE) && pip install flake8 black
+
+clean-venv:
+	@rm -rf $(VENV_DIR)
+
 run:
-	@(cd src; python -m bibleit)
+	@(cd $(SOURCE_DIR); python -m bibleit)
 
 bump-version:
 	@./bump-version.sh
 
-lint:
-	@flake8 --config=.flake8 .
+lint: $(VENV_DIR)
+	@$(VENV_ACTIVATE) && flake8 --config=.flake8 $(SOURCE_DIR)
 
-fix-lint:
-	black .
+fix-lint: $(VENV_DIR)
+	@$(VENV_ACTIVATE) && black $(SOURCE_DIR)


### PR DESCRIPTION
In order to lint tools, we should make sure we have them proper installed into our Python packages.

Add a virtual env integration in order to create a isolated environment to run `black`, `flake8` and any other dev dependency.