### PR TITLE
Fixing regex for reference search

### DIFF
--- a/src/bibleit/bible.py
+++ b/src/bibleit/bible.py
@@ -113,7 +113,7 @@ class Bible:
         return [
             line
             for line, (_, normalized) in self.content
-            if re.search(rf"^{book}.* {name}:({verse})", normalized, re.IGNORECASE)
+            if re.search(rf"^{book}.* {name}:({verse}) ", normalized, re.IGNORECASE)
         ]
 
     def chapters(self):


### PR DESCRIPTION
Regex was missing a space, search results were broken.

Searching for 1 Jo 1, would bring verses 1, 11, 12, 13, etc. 


