### PR TITLE
feat(python): add search history pane and native build prerequisite

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run repl bump-version lint fix-lint test build local-install-test FORCE
+.PHONY: run native native-clean repl bump-version lint fix-lint test build local-install-test FORCE
 
 VENV_DIR:=.venv
 VENV_ACTIVATE:=. $(VENV_DIR)/bin/activate
@@ -11,6 +11,32 @@ PYTHON_BIN?=$(or \
 	$(shell command -v python3.13 2>/dev/null),\
 	python3)
 SOURCE_DIR:=src
+LIBBIBLEIT_DIR:=$(abspath ../libbibleit)
+NATIVE_DIR:=$(SOURCE_DIR)/bibleit/_native
+UNAME_S:=$(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+NATIVE_LIB:=libbibleit.dylib
+else
+NATIVE_LIB:=libbibleit.so
+endif
+NATIVE_STAMP:=$(NATIVE_DIR)/$(NATIVE_LIB)
+LIBBIBLEIT_SRCS:=$(wildcard $(LIBBIBLEIT_DIR)/src/*.c $(LIBBIBLEIT_DIR)/include/bibleit/*.h)
+
+$(NATIVE_STAMP): $(LIBBIBLEIT_SRCS) $(LIBBIBLEIT_DIR)/Makefile
+	@test -f $(LIBBIBLEIT_DIR)/Makefile || (echo "libbibleit not found at $(LIBBIBLEIT_DIR)" >&2; exit 1)
+	$(MAKE) -C $(LIBBIBLEIT_DIR)
+	@mkdir -p $(NATIVE_DIR)
+	@touch $(NATIVE_DIR)/__init__.py
+	cp -Lf $(LIBBIBLEIT_DIR)/$(NATIVE_LIB) $@
+ifeq ($(UNAME_S),Darwin)
+	@command -v codesign >/dev/null 2>&1 && codesign --force --sign - $@ || true
+endif
+
+native: $(NATIVE_STAMP)
+
+native-clean:
+	$(MAKE) -C $(LIBBIBLEIT_DIR) clean
+	@rm -f $(NATIVE_DIR)/$(NATIVE_LIB) $(NATIVE_DIR)/libbibleit.so.*
 
 $(VENV_DIR):
 	$(PYTHON_BIN) -m venv $@
@@ -29,7 +55,7 @@ install: $(VENV_DEPS_FILE)
 clean-venv:
 	@rm -rf $(VENV_DIR)
 
-run: $(VENV_DEPS_FILE)
+run: $(VENV_DEPS_FILE) $(NATIVE_STAMP)
 	@$(VENV_ACTIVATE) && (cd $(SOURCE_DIR); python -m bibleit)
 
 serve: $(VENV_DEPS_FILE)

--- a/python/src/bibleit/app.py
+++ b/python/src/bibleit/app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from textual.app import App
-from textual.containers import Container, Horizontal, Vertical
+from textual.containers import Container, Horizontal
 from textual.binding import Binding
 from textual.widgets import ListView, ListItem, Input, Tree, Footer, Label, Static, Button, Switch
 from textual.screen import Screen
@@ -38,46 +38,27 @@ import asyncio
 from rich.markup import escape
 
 
-class HistoryPane(Vertical):
-    can_focus = True
-    can_focus_children = True
-    pane_open = reactive(False)
-
+class HistoryScreen(Screen):
     BINDINGS = [
-        ("escape", "close_pane", "Close"),
-        Binding("tab", "focus_filter", "Filter", show=True),
-        Binding("shift+tab", "focus_list", "Verses", show=True),
+        ("escape", "close_screen", "Close"),
+        ("ctrl+h", "close_screen", "History"),
         Binding("enter", "go_to_selected", "Go To", priority=True),
     ]
 
     def __init__(self) -> None:
         super().__init__()
-        self.history = SessionHistory()
         self._filter = ""
         self._navigating = False
 
     def compose(self):
-        yield Label("History", id="history-title")
-        yield Input(placeholder="Filter verses…", id="history-filter")
-        yield ListView(id="history-list")
+        with Container(id="history-panel"):
+            yield Label("History", id="history-title")
+            yield Input(placeholder="Filter verses…", id="history-filter")
+            yield ListView(id="history-list")
 
-    def watch_pane_open(self, pane_open: bool) -> None:
-        self.set_class(pane_open, "open")
-        if pane_open:
-            self._refresh_list()
-            self.call_after_refresh(self.action_focus_list)
-
-    def toggle(self) -> None:
-        self.pane_open = not self.pane_open
-        if self.pane_open:
-            self.focus()
-
-    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        if action == "focus_filter":
-            return self._history_list_focused()
-        if action == "focus_list":
-            return self._history_filter_focused()
-        return True
+    def on_mount(self) -> None:
+        self._refresh_list()
+        self.call_after_refresh(self.action_focus_filter)
 
     def _history_list(self) -> ListView:
         return self.query_one("#history-list", ListView)
@@ -109,37 +90,13 @@ class HistoryPane(Vertical):
     def action_focus_filter(self) -> None:
         self._history_filter().focus()
 
-    def record(
-        self,
-        translation_: translation.Translation,
-        ref: translation.TranslationRef,
-    ) -> None:
-        if self._navigating:
-            return
-
-        chapter = ref.chapter or 1
-        verse = ref.verse_start or 1
-        label = verse_reference_label(translation_, ref.bookid, chapter, verse)
-        self.history.record(
-            HistoryEntry(
-                bookid=ref.bookid,
-                chapter=chapter,
-                verse=verse,
-                label=label,
-            )
-        )
-
-        if self.pane_open:
-            self._refresh_list()
-
     def navigate_to(self, entry: HistoryEntry) -> None:
         bible_view = self.app.query_exactly_one(BibleView)
         self._navigating = True
         try:
             bible_view.go_to_ref(entry.as_ref())
-            self.history.record(entry)
-            if self.pane_open:
-                self._refresh_list()
+            self.app.record_history_entry(entry)
+            self.app.pop_screen()
         finally:
             self._navigating = False
 
@@ -147,8 +104,8 @@ class HistoryPane(Vertical):
         list_view = self._history_list()
         previous_index = list_view.index if keep_index else None
         list_view.clear()
-        for entry in self.history.entries(self._filter):
-            item = ListItem(Label(entry.label))
+        for entry in self.app.history.entries(self._filter):
+            item = ListItem(Label(entry.label, classes="history-entry"))
             item.entry = entry
             list_view.append(item)
 
@@ -161,12 +118,14 @@ class HistoryPane(Vertical):
             list_view.index = 0
 
     async def on_key(self, event: events.Key) -> None:
-        if not self.pane_open:
-            return
-
         if event.key == "escape":
             event.stop()
-            self.action_close_pane()
+            self.action_close_screen()
+            return
+
+        if self._history_filter_focused() and event.key == "down":
+            event.stop()
+            self.action_focus_list()
             return
 
         if self._history_list_focused() and event.key in ("up", "down"):
@@ -177,6 +136,9 @@ class HistoryPane(Vertical):
             if event.key == "down":
                 list_view.action_cursor_down()
             else:
+                if list_view.index in (None, 0):
+                    self.action_focus_filter()
+                    return
                 list_view.action_cursor_up()
 
     def on_input_changed(self, event: Input.Changed) -> None:
@@ -208,10 +170,8 @@ class HistoryPane(Vertical):
         if entry is not None:
             self.navigate_to(entry)
 
-    def action_close_pane(self) -> None:
-        if not self.pane_open:
-            return
-        self.pane_open = False
+    def action_close_screen(self) -> None:
+        self.app.pop_screen()
         self.app.query_exactly_one(BibleView).focus()
 
 
@@ -244,6 +204,7 @@ class StatusBar(Horizontal):
         yield Static(id="status-command-completions")
         with Container(id="status-actions"):
             yield Button("Find", id="action-find")
+            yield Button("History", id="action-history")
             yield Button("Translations", id="action-translations")
             yield Button("Strongs", id="action-strongs")
             yield Button("Config", id="action-config")
@@ -317,6 +278,7 @@ class StatusBar(Horizontal):
         actions = {
             "action-menu": self.action_toggle_menu,
             "action-find": bible_view.action_open_find,
+            "action-history": bible_view.action_toggle_history,
             "action-translations": bible_view.action_open_translations,
             "action-strongs": bible_view.action_toggle_strongs,
             "action-config": bible_view.action_open_config,
@@ -636,7 +598,7 @@ class Find(Screen):
     def _open_result(self, result: TextFindResult) -> None:
         bible_view = self.app.query_exactly_one(BibleView)
         bible_view.go_to_ref(result.ref)
-        self.app.query_one(HistoryPane).record(self.view.translation, result.ref)
+        self.app.record_history(self.view.translation, result.ref)
         self.app.pop_screen()
 
     def action_open_selected(self) -> None:
@@ -1040,6 +1002,7 @@ class ShortcutsScreen(OverlayStatusMixin, Screen):
         ("Ctrl+T", "Translations"),
         ("Ctrl+F", "Find text"),
         ("Ctrl+G", "Strongs"),
+        ("Ctrl+H", "History"),
         ("Ctrl+P", "Config"),
         ("Ctrl+D", "Toggle theme"),
         ("Ctrl+W", "Close pane"),
@@ -1088,6 +1051,7 @@ class WelcomeScreen(OverlayStatusMixin, Screen):
             "ctrl+t": lambda view: view.action_open_translations(),
             "ctrl+f": lambda view: view.action_open_find(),
             "ctrl+g": lambda view: view.action_toggle_strongs(),
+            "ctrl+h": lambda view: view.action_toggle_history(),
             "ctrl+l": lambda view: view.action_toggle_live(),
             "ctrl+p": lambda view: view.action_open_config(),
             "ctrl+d": lambda view: self.app.action_toggle_theme(),
@@ -1692,6 +1656,7 @@ class BibleView(Horizontal):
         ("ctrl+t", "open_translations", "Translations"),
         ("ctrl+f", "open_find", "Find"),
         ("ctrl+g", "toggle_strongs", "Strongs"),
+        ("ctrl+h", "toggle_history", "History"),
         ("ctrl+p", "open_config", "Config"),
         ("ctrl+l", "toggle_live", "Live"),
         ("ctrl+w", "close_pane", "Close Pane"),
@@ -1791,7 +1756,7 @@ class BibleView(Horizontal):
             return False
 
         self.go_to_ref(ref)
-        self.app.query_one(HistoryPane).record(view.translation, ref)
+        self.app.record_history(view.translation, ref)
         return True
 
     def on_mount(self):
@@ -1833,6 +1798,13 @@ class BibleView(Horizontal):
             return
 
         self.app.push_screen(ConfigScreen())
+
+    def action_toggle_history(self) -> None:
+        if isinstance(self.app.screen, HistoryScreen):
+            self.app.pop_screen()
+            self.focus()
+        else:
+            self.app.push_screen(HistoryScreen())
 
     async def action_previous_verse(self):
         view = self.focused_view() or (self.views[0] if self.views else None)
@@ -2026,6 +1998,7 @@ class Bibleit(App):
 
     def __init__(self):
         super().__init__()
+        self.history = SessionHistory()
         self.dark_theme = theme_is_dark()
         atexit.register(self._disable_live_on_shutdown)
 
@@ -2089,8 +2062,27 @@ class Bibleit(App):
         self.theme = "textual-dark" if dark else "textual-light"
         self.set_class(self.dark_theme, "dark")
 
+    def record_history(
+        self,
+        translation_: translation.Translation,
+        ref: translation.TranslationRef,
+    ) -> None:
+        chapter = ref.chapter or 1
+        verse = ref.verse_start or 1
+        label = verse_reference_label(translation_, ref.bookid, chapter, verse)
+        self.record_history_entry(
+            HistoryEntry(
+                bookid=ref.bookid,
+                chapter=chapter,
+                verse=verse,
+                label=label,
+            )
+        )
+
+    def record_history_entry(self, entry: HistoryEntry) -> None:
+        self.history.record(entry)
+
     def compose(self):
         with Horizontal(id="workspace"):
             yield BibleView()
-            yield HistoryPane()
         yield StatusBar()

--- a/python/src/bibleit/app.tcss
+++ b/python/src/bibleit/app.tcss
@@ -569,10 +569,72 @@ StatusBar.browser.compact.open {
   height: 2;
 }
 
-BibleView {
+#workspace {
   width: 100%;
   height: 1fr;
+}
+
+BibleView {
+  width: 1fr;
+  height: 100%;
   background: #f3f1ed;
+}
+
+HistoryPane {
+  display: none;
+  width: 30;
+  height: 100%;
+  layout: vertical;
+  background: #ece8e1;
+  border-left: solid #ddd4c8;
+  padding: 0 1;
+}
+
+HistoryPane.open {
+  display: block;
+}
+
+#history-title {
+  width: 100%;
+  height: 1;
+  padding: 1 0 0 0;
+  color: #2a2a2a;
+  text-style: bold;
+}
+
+#history-filter {
+  width: 100%;
+  height: 3;
+  margin: 1 0;
+  background: #f8f5ef;
+  color: #202020;
+  border: tall #b98b4d;
+  padding: 0 1;
+}
+
+#history-filter:focus {
+  border: tall #9f6d2f;
+}
+
+#history-list {
+  height: 1fr;
+  background: #ece8e1;
+  scrollbar-size-vertical: 1;
+}
+
+#history-list > ListItem {
+  height: 1;
+}
+
+#history-list > ListItem.-highlight {
+  background: #e7c878;
+  color: #1f1f1f;
+  text-style: bold;
+}
+
+#history-list > ListItem > Label {
+  padding: 0 1;
+  text-overflow: ellipsis;
 }
 
 BibleView.vertical {

--- a/python/src/bibleit/app.tcss
+++ b/python/src/bibleit/app.tcss
@@ -50,40 +50,6 @@ ListItem {
   }
 }
 
-HistoryPane {
-  display: none;
-  width: 42%;
-  max-width: 48;
-  height: 100%;
-  padding: 1;
-  background: #ece8e1;
-  border-left: solid #d6cfc5;
-}
-
-HistoryPane.open {
-  display: block;
-}
-
-#history-title {
-  width: 100%;
-  height: 2;
-  text-style: bold;
-}
-
-#history-filter {
-  width: 100%;
-  height: 3;
-  margin-bottom: 1;
-  background: #f8f5ef;
-  color: #202020;
-  border: tall #b98b4d;
-}
-
-#history-list {
-  width: 100%;
-  height: 1fr;
-}
-
 Footer {
   background: #ece8e1;
   color: #2a2a2a;
@@ -580,61 +546,71 @@ BibleView {
   background: #f3f1ed;
 }
 
-HistoryPane {
-  display: none;
-  width: 30;
-  height: 100%;
-  layout: vertical;
-  background: #ece8e1;
-  border-left: solid #ddd4c8;
-  padding: 0 1;
+HistoryScreen {
+  layer: overlay;
+  align: center middle;
+  background: #00000066;
 }
 
-HistoryPane.open {
-  display: block;
+#history-panel {
+  width: 54;
+  max-width: 86%;
+  height: 70%;
+  max-height: 80%;
+  layout: vertical;
+  background: #ece8e1;
+  border: round #c89b5d;
+  padding: 1 2;
 }
 
 #history-title {
   width: 100%;
-  height: 1;
-  padding: 1 0 0 0;
-  color: #2a2a2a;
+  height: 2;
+  color: #d97706;
   text-style: bold;
 }
 
 #history-filter {
   width: 100%;
-  height: 3;
-  margin: 1 0;
+  height: 1;
+  margin: 0 0 1 0;
   background: #f8f5ef;
   color: #202020;
-  border: tall #b98b4d;
+  border: none;
   padding: 0 1;
 }
 
 #history-filter:focus {
-  border: tall #9f6d2f;
+  background: #f8f5ef;
+  color: #202020;
 }
 
 #history-list {
   height: 1fr;
-  background: #ece8e1;
-  scrollbar-size-vertical: 1;
+  background: transparent;
+  scrollbar-size: 0 0;
 }
 
 #history-list > ListItem {
-  height: 1;
+  height: auto;
+  background: transparent;
+  color: #2a2a2a;
+  margin-bottom: 0;
 }
 
 #history-list > ListItem.-highlight {
   background: #e7c878;
   color: #1f1f1f;
-  text-style: bold;
+  border-left: thick #d97706;
+  text-style: italic bold;
 }
 
 #history-list > ListItem > Label {
-  padding: 0 1;
-  text-overflow: ellipsis;
+  width: 100%;
+  height: auto;
+  padding: 0 1 0 1;
+  text-wrap: wrap;
+  text-overflow: fold;
 }
 
 BibleView.vertical {
@@ -697,9 +673,9 @@ Bibleit.dark BibleView.vertical View {
   border-bottom: solid #2a2724;
 }
 
-Bibleit.dark HistoryPane {
-  background: #171717;
-  border-left: solid #2c2926;
+Bibleit.dark #history-panel {
+  background: #141414;
+  color: #f1ede6;
 }
 
 Bibleit.dark #history-filter,
@@ -708,6 +684,29 @@ Bibleit.dark ConfigScreen Input {
   background: #202020;
   color: #f1ede6;
   border: tall #5f564d;
+}
+
+Bibleit.dark #history-filter:focus {
+  background: #202020;
+  color: #f1ede6;
+  border: none;
+}
+
+Bibleit.dark #history-list,
+Bibleit.dark #history-list > ListItem {
+  background: #171717;
+  color: #d8d0c7;
+}
+
+Bibleit.dark #history-list > ListItem.-highlight {
+  background: #c4933e;
+  color: #15120e;
+  border-left: thick #d97706;
+  text-style: italic bold;
+}
+
+Bibleit.dark #history-list > ListItem.-highlight > Label {
+  color: #15120e;
 }
 
 Bibleit.dark Footer,

--- a/python/src/bibleit/history.py
+++ b/python/src/bibleit/history.py
@@ -45,6 +45,14 @@ class SessionHistory:
             return ordered
 
         labels = [unidecode(entry.label.lower()) for entry in ordered]
+        direct_matches = [
+            entry
+            for entry, label in zip(ordered, labels)
+            if _matches_history_text(normalized, label)
+        ]
+        if len(normalized) <= 2:
+            return direct_matches
+
         matches = process.extract(
             normalized,
             labels,
@@ -53,4 +61,23 @@ class SessionHistory:
             limit=len(ordered),
         )
         label_to_entry = dict(zip(labels, ordered))
-        return [label_to_entry[match[0]] for match in matches]
+        fuzzy_matches = [label_to_entry[match[0]] for match in matches]
+        return _unique_entries([*direct_matches, *fuzzy_matches])
+
+
+def _matches_history_text(query: str, label: str) -> bool:
+    if query in label:
+        return True
+
+    return any(word.startswith(query) for word in label.split())
+
+
+def _unique_entries(entries: list[HistoryEntry]) -> list[HistoryEntry]:
+    seen = set()
+    unique = []
+    for entry in entries:
+        if entry.key in seen:
+            continue
+        unique.append(entry)
+        seen.add(entry.key)
+    return unique

--- a/python/src/bibleit/test_app.py
+++ b/python/src/bibleit/test_app.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from tempfile import TemporaryDirectory
 import asyncio
 
-from textual.widgets import ListItem, Switch
+from textual.widgets import Button, Label, ListItem, ListView, Switch
 
 try:
     from bibleit import translation
@@ -15,6 +15,7 @@ try:
         Bibleit,
         ConfigScreen,
         HistoryEntry,
+        HistoryScreen,
         LivePublisher,
         NavigationState,
         RowRef,
@@ -234,6 +235,26 @@ class SessionHistoryTests(unittest.TestCase):
         history.record(HistoryEntry(43, 3, 16, "John 3:16"))
 
         filtered = history.entries("john 3:16")
+
+        self.assertEqual([entry.label for entry in filtered], ["John 3:16"])
+
+    def test_entries_filters_from_first_letter(self):
+        history = SessionHistory()
+        history.record(HistoryEntry(1, 1, 1, "Genesis 1:1"))
+        history.record(HistoryEntry(19, 23, 1, "Psalms 23:1"))
+        history.record(HistoryEntry(43, 3, 16, "John 3:16"))
+
+        filtered = history.entries("j")
+
+        self.assertEqual([entry.label for entry in filtered], ["John 3:16"])
+
+    def test_entries_filters_from_second_letter(self):
+        history = SessionHistory()
+        history.record(HistoryEntry(1, 1, 1, "Genesis 1:1"))
+        history.record(HistoryEntry(19, 23, 1, "Psalms 23:1"))
+        history.record(HistoryEntry(43, 3, 16, "John 3:16"))
+
+        filtered = history.entries("jo")
 
         self.assertEqual([entry.label for entry in filtered], ["John 3:16"])
 
@@ -611,6 +632,118 @@ class ConfigTests(unittest.TestCase):
                 await pilot.pause()
 
                 self.assertTrue(app.query_exactly_one(StatusBar).command_mode)
+
+        asyncio.run(run())
+
+    def test_ctrl_h_toggles_history_screen(self):
+        async def run():
+            app = Bibleit()
+
+            async with app.run_test() as pilot:
+                app.pop_screen()
+                bible_view = app.query_exactly_one(BibleView)
+                bible_view.focus()
+                await pilot.pause()
+
+                self.assertNotIsInstance(app.screen, HistoryScreen)
+
+                await pilot.press("ctrl+h")
+                await pilot.pause()
+
+                self.assertIsInstance(app.screen, HistoryScreen)
+
+                await pilot.press("ctrl+h")
+                await pilot.pause()
+
+                self.assertNotIsInstance(app.screen, HistoryScreen)
+
+        asyncio.run(run())
+
+    def test_history_status_button_opens_history_screen(self):
+        async def run():
+            app = Bibleit()
+
+            async with app.run_test() as pilot:
+                app.pop_screen()
+                await pilot.pause()
+
+                self.assertNotIsInstance(app.screen, HistoryScreen)
+
+                status = app.query_exactly_one(StatusBar)
+                button = status.query_one("#action-history", Button)
+                await status.on_button_pressed(Button.Pressed(button))
+                await pilot.pause()
+
+                self.assertIsInstance(app.screen, HistoryScreen)
+                self.assertIsNotNone(app.screen.query_one("#history-title", Label))
+
+        asyncio.run(run())
+
+    def test_history_entries_are_wrapped(self):
+        async def run():
+            app = Bibleit()
+
+            async with app.run_test() as pilot:
+                app.pop_screen()
+                app.history.record(
+                    HistoryEntry(
+                        46,
+                        1,
+                        1,
+                        "Carta de Paulo aos Coríntios 1:1",
+                    )
+                )
+                app.push_screen(HistoryScreen())
+                await pilot.pause()
+
+                history = app.screen
+                row = history.query_one("#history-list", ListView).children[0]
+                label = row.query_one(Label)
+
+                self.assertEqual(str(row.styles.height), "auto")
+                self.assertEqual(str(row.styles.margin.bottom), "0")
+                self.assertEqual(str(label.styles.height), "auto")
+                self.assertEqual(label.styles.text_overflow, "fold")
+
+        asyncio.run(run())
+
+    def test_history_down_from_filter_focuses_first_entry(self):
+        async def run():
+            app = Bibleit()
+
+            async with app.run_test() as pilot:
+                app.pop_screen()
+                app.history.record(HistoryEntry(1, 1, 1, "Genesis 1:1"))
+                app.push_screen(HistoryScreen())
+                await pilot.pause()
+
+                history = app.screen
+                history.action_focus_filter()
+                await pilot.pause()
+                await pilot.press("down")
+                await pilot.pause()
+
+                list_view = history.query_one("#history-list", ListView)
+                self.assertIs(app.focused, list_view)
+                self.assertEqual(list_view.index, 0)
+
+        asyncio.run(run())
+
+    def test_history_up_from_first_entry_focuses_filter(self):
+        async def run():
+            app = Bibleit()
+
+            async with app.run_test() as pilot:
+                app.pop_screen()
+                app.history.record(HistoryEntry(1, 1, 1, "Genesis 1:1"))
+                app.push_screen(HistoryScreen())
+                await pilot.pause()
+
+                history = app.screen
+                await pilot.press("up")
+                await pilot.pause()
+
+                self.assertIs(app.focused, history.query_one("#history-filter"))
 
         asyncio.run(run())
 

--- a/python/src/bibleit/test_live.py
+++ b/python/src/bibleit/test_live.py
@@ -56,8 +56,10 @@ class LiveVerseTest(unittest.TestCase):
         self.assertNotIn("__all__", rendered)
 
     def test_control_requests_are_open_without_token(self):
-        with patch.dict("os.environ", {}, clear=True):
-            app = create_app("test live")
+        with TemporaryDirectory() as temp:
+            path = f"{temp}/config"
+            with patch.dict("os.environ", {"BIBLEIT_CONFIG_FILE": path}, clear=True):
+                app = create_app("test live")
 
         request = make_mocked_request("POST", "/api/publish", app=app)
 


### PR DESCRIPTION
Add a toggleable LRU history panel for Ctrl+S verse searches with fuzzy
filtering, list-first keyboard navigation, and Escape to close. Wire
libbibleit compilation into make run via a native Makefile target.

